### PR TITLE
use PLURALIZED_MODEL_NAME instend of TABLE_NAME

### DIFF
--- a/lib/annotate/annotate_models.rb
+++ b/lib/annotate/annotate_models.rb
@@ -116,8 +116,8 @@ module AnnotateModels
 
     def fixture_files(root_directory)
       [
-        File.join(root_directory, FIXTURE_TEST_DIR, "%TABLE_NAME%.yml"),
-        File.join(root_directory, FIXTURE_SPEC_DIR, "%TABLE_NAME%.yml"),
+        # File.join(root_directory, FIXTURE_TEST_DIR, "%TABLE_NAME%.yml"),
+        # File.join(root_directory, FIXTURE_SPEC_DIR, "%TABLE_NAME%.yml"),
         File.join(root_directory, FIXTURE_TEST_DIR, "%PLURALIZED_MODEL_NAME%.yml"),
         File.join(root_directory, FIXTURE_SPEC_DIR, "%PLURALIZED_MODEL_NAME%.yml")
       ]
@@ -140,8 +140,8 @@ module AnnotateModels
         File.join(root_directory, BLUEPRINTS_SPEC_DIR,    "%MODEL_NAME%_blueprint.rb"),
         File.join(root_directory, FACTORY_GIRL_TEST_DIR,  "%MODEL_NAME%_factory.rb"),    # (old style)
         File.join(root_directory, FACTORY_GIRL_SPEC_DIR,  "%MODEL_NAME%_factory.rb"),    # (old style)
-        File.join(root_directory, FACTORY_GIRL_TEST_DIR,  "%TABLE_NAME%.rb"),            # (new style)
-        File.join(root_directory, FACTORY_GIRL_SPEC_DIR,  "%TABLE_NAME%.rb"),            # (new style)
+        # File.join(root_directory, FACTORY_GIRL_TEST_DIR,  "%TABLE_NAME%.rb"),            # (new style)
+        # File.join(root_directory, FACTORY_GIRL_SPEC_DIR,  "%TABLE_NAME%.rb"),            # (new style)
         File.join(root_directory, FACTORY_GIRL_TEST_DIR,  "%PLURALIZED_MODEL_NAME%.rb"), # (new style)
         File.join(root_directory, FACTORY_GIRL_SPEC_DIR,  "%PLURALIZED_MODEL_NAME%.rb"), # (new style)
         File.join(root_directory, FABRICATORS_TEST_DIR,   "%MODEL_NAME%_fabricator.rb"),


### PR DESCRIPTION
统一使用 PLURALIZED_MODEL_NAME 来注解 factory 文件， 避免模型名字一样，但表结构不一致导致的注解冲突。

比如:

```
app/models/foo.rb             => test/factories/foos.rb
app/models/cherry/foo.rb  => test/factories/cherry/foos.rb # 不再去注解 test/factories/foos.rb
```